### PR TITLE
ForecastAccessService Dto

### DIFF
--- a/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/dao/access/ForecastAccessService.java
+++ b/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/dao/access/ForecastAccessService.java
@@ -5,12 +5,11 @@ import net.c7j.weather.geomagnetic.dao.entity.ForecastEntity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.stream.Stream;
 
 public interface ForecastAccessService {
 
-    void upsert(Collection<ForecastEntity> collection);
+    void save(Stream<ForecastDto> forecasts);
 
     Stream<ForecastDto> findDiurnal(LocalDate today);
 

--- a/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/dao/access/impl/ForecastAccessServiceImpl.java
+++ b/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/dao/access/impl/ForecastAccessServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.util.Assert;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Collection;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -32,10 +32,11 @@ public class ForecastAccessServiceImpl implements ForecastAccessService {
     }
 
     @Override
-    public void upsert(Collection<ForecastEntity> collection) {
-        Assert.notEmpty(collection, "The 'collection' shouldn't be null or empty!");
+    public void save(Stream<ForecastDto> forecasts) {
+        Assert.notNull(forecasts, "The 'collection' shouldn't be null!");
         LOGGER.info("A collection of a 'ForecastEntity' will be saved or updated.");
-        forecastRepository.saveAll(collection);
+        var forecastEntities = mapper.convertToEntity(forecasts).collect(Collectors.toList());
+        forecastRepository.saveAll(forecastEntities);
     }
 
     @Override

--- a/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/dao/dto/ForecastDto.java
+++ b/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/dao/dto/ForecastDto.java
@@ -7,16 +7,23 @@ import net.c7j.weather.geomagnetic.util.JsonWriter;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
 public class ForecastDto implements Comparable<ForecastDto> {
+
+    @JsonProperty(value = "id")
+    private Long id;
 
     @JsonProperty(value = "value")
     private IndexType index;
 
     @JsonProperty(value = "time")
     private Long time;
+
+    public ForecastDto(IndexType index, Long time) {
+        this.index = index;
+        this.time = time;
+    }
 
     public ForecastDto(int index, Long time) {
         this.index = IndexType.indexOf(index);

--- a/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/mapper/impl/ForecastDtoMapper.java
+++ b/geomagnetic-api/src/main/java/net/c7j/weather/geomagnetic/mapper/impl/ForecastDtoMapper.java
@@ -7,8 +7,7 @@ import net.c7j.weather.geomagnetic.service.DtoMapperChecker;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.util.function.BiConsumer;
 
 @Component
@@ -23,6 +22,9 @@ public class ForecastDtoMapper extends AbstractDtoMapper<ForecastEntity, Forecas
         modelMapper
                 .createTypeMap(entityClass, dtoClass)
                 .setPostConverter(toDtoConverter(new DtoConverter()));
+        modelMapper
+                .createTypeMap(dtoClass, entityClass)
+                .setPostConverter(toEntityConverter(new EntityConverter()));
     }
 
     public static class DtoConverter implements BiConsumer<ForecastEntity, ForecastDto>, DtoMapperChecker {
@@ -36,6 +38,23 @@ public class ForecastDtoMapper extends AbstractDtoMapper<ForecastEntity, Forecas
             var forecastTime = LocalDateTime.of(entity.getForecastDate(), entity.getForecastTime());
             var greenwichZone = forecastTime.atZone(ZoneOffset.UTC);
             return greenwichZone.toInstant().getEpochSecond();
+        }
+    }
+
+    public static class EntityConverter implements BiConsumer<ForecastDto, ForecastEntity>, DtoMapperChecker {
+
+        @Override
+        public void accept(ForecastDto dto, ForecastEntity entity) {
+            whenNotNull(dto, it -> entity.setForecastDate(getLocalDate(it.getTime())));
+            whenNotNull(dto, it -> entity.setForecastTime(getLocalTime(it.getTime())));
+        }
+
+        private LocalDate getLocalDate(Long mills) {
+            return Instant.ofEpochMilli(mills).atZone(ZoneOffset.UTC).toLocalDate();
+        }
+
+        private LocalTime getLocalTime(Long mills) {
+            return Instant.ofEpochMilli(mills).atZone(ZoneOffset.UTC).toLocalTime();
         }
     }
 }

--- a/geomagnetic-api/src/test/java/net/c7j/weather/geomagnetic/event/listener/ForecastListenerTest.java
+++ b/geomagnetic-api/src/test/java/net/c7j/weather/geomagnetic/event/listener/ForecastListenerTest.java
@@ -48,11 +48,11 @@ class ForecastListenerTest {
     @DisplayName("onEvent(): a successful call")
     void successfulOnEvent() {
         when(forecastUpsertServiceMock.upsertForecasts(any(), any())).thenReturn(Stream.empty());
-        doNothing().when(forecastAccessServiceMock).upsert(anyCollection());
+        doNothing().when(forecastAccessServiceMock).save(any());
 
         forecastListener.onEvent(GeneratorHelper.generateTxtForecastDto(LocalDate.now()));
         verify(forecastUpsertServiceMock, timeout(DEFAULT_TIMEOUT).only()).upsertForecasts(any(), any());
-        verify(forecastAccessServiceMock, timeout(DEFAULT_TIMEOUT).only()).upsert(anyCollection());
+        verify(forecastAccessServiceMock, timeout(DEFAULT_TIMEOUT).only()).save(any());
     }
 
     //  -----------------------   unsuccessful tests   -------------------------
@@ -62,6 +62,6 @@ class ForecastListenerTest {
     void unsuccessfulOnEvent() {
         forecastListener.onEvent(null);
         verify(forecastUpsertServiceMock, timeout(DEFAULT_TIMEOUT).times(0)).upsertForecasts(any(), any());
-        verify(forecastAccessServiceMock, timeout(DEFAULT_TIMEOUT).times(0)).upsert(anyCollection());
+        verify(forecastAccessServiceMock, timeout(DEFAULT_TIMEOUT).times(0)).save(any());
     }
 }


### PR DESCRIPTION
 - [x] Изменить ForecastAccessService.upsert() под dto аргумент
 - [x] Исправить в тестах

added an 'id' field to ForecastDto
fixed ForecastAccessService.upsert(entity) to ForecastAccessService.upsert(dto)
renamed ForecastAccessService.upsert() to ForecastAccessService.save()
fixed a broken test